### PR TITLE
Enable support for WFA 11n and 11ac STA cert programs for generic mac80211 drivers

### DIFF
--- a/sigma_dut.h
+++ b/sigma_dut.h
@@ -969,6 +969,15 @@ struct sigma_dut {
 
 	int sta_vht_mcs_nss[2][4];
 
+#define mod_ht_cap(dut, cap, val) \
+	do { \
+		dut->cap = val; \
+	} while(0);
+
+	int ht40_intolerant;
+	int disable_ldpc;
+	int disable_sgi;
+
 #ifdef ANDROID
 	int nanservicediscoveryinprogress;
 #endif /* ANDROID */

--- a/sigma_dut.h
+++ b/sigma_dut.h
@@ -934,6 +934,40 @@ struct sigma_dut {
 
 	int sta_nss;
 
+#ifndef BIT
+#define BIT(x) (1U << (x))
+#endif
+
+#define mod_cap_bit(dut, bit, val) \
+        do { \
+		dut->sta_vhtcaps_mask |= bit; \
+		if (val) \
+			dut->sta_vhtcaps |= bit; \
+		else \
+			dut->sta_vhtcaps &= ~bit; \
+        } while (0)
+
+#define VHT_CAP_RXLDPC                              ((u32) BIT(4))
+#define VHT_CAP_SHORT_GI_80                         ((u32) BIT(5))
+#define VHT_CAP_SU_BEAMFORMEE_CAPABLE               ((u32) BIT(12))
+#define VHT_CAP_BEAMFORMEE_STS_MAX                  ((u32) BIT(13) | BIT(14) | BIT(15))
+#define VHT_CAP_BEAMFORMEE_STS_MAX_SHIFT            13
+#define VHT_CAP_BEAMFORMEE_STS_OFFSET               13
+#define VHT_CAP_MU_BEAMFORMEE_CAPABLE               ((u32) BIT(20))
+
+	u32 sta_vhtcaps;
+	u32 sta_vhtcaps_mask;
+
+#define RX_SS_ID	0
+#define TX_SS_ID	1
+
+#define IEEE80211_VHT_MCS_0_7	0
+#define IEEE80211_VHT_MCS_0_8	1
+#define IEEE80211_VHT_MCS_0_9	2
+#define IEEE80211_VHT_MCS_NA	3
+
+	int sta_vht_mcs_nss[2][4];
+
 #ifdef ANDROID
 	int nanservicediscoveryinprogress;
 #endif /* ANDROID */

--- a/sigma_dut.h
+++ b/sigma_dut.h
@@ -949,6 +949,7 @@ struct sigma_dut {
 
 #define VHT_CAP_RXLDPC                              ((u32) BIT(4))
 #define VHT_CAP_SHORT_GI_80                         ((u32) BIT(5))
+#define VHT_CAP_SHORT_GI_160                        ((u32) BIT(6))
 #define VHT_CAP_SU_BEAMFORMEE_CAPABLE               ((u32) BIT(12))
 #define VHT_CAP_BEAMFORMEE_STS_MAX                  ((u32) BIT(13) | BIT(14) | BIT(15))
 #define VHT_CAP_BEAMFORMEE_STS_MAX_SHIFT            13

--- a/sigma_dut.h
+++ b/sigma_dut.h
@@ -938,7 +938,7 @@ struct sigma_dut {
 #define BIT(x) (1U << (x))
 #endif
 
-#define mod_cap_bit(dut, bit, val) \
+#define mod_vht_cap_bit(dut, bit, val) \
         do { \
 		dut->sta_vhtcaps_mask |= bit; \
 		if (val) \

--- a/sigma_dut.h
+++ b/sigma_dut.h
@@ -1180,6 +1180,8 @@ int random_get_bytes(char *buf, size_t len);
 int get_enable_disable(const char *val);
 int wcn_driver_cmd(const char *ifname, char *buf);
 
+int get_phy80211_name(struct sigma_dut *dut, const char *intf);
+
 /* uapsd_stream.c */
 void receive_uapsd(struct sigma_stream *s);
 void send_uapsd_console(struct sigma_stream *s);

--- a/sigma_dut.h
+++ b/sigma_dut.h
@@ -977,6 +977,8 @@ struct sigma_dut {
 	int ht40_intolerant;
 	int disable_ldpc;
 	int disable_sgi;
+	int rx_stbc;
+	int tx_stbc;
 
 #ifdef ANDROID
 	int nanservicediscoveryinprogress;

--- a/sta.c
+++ b/sta.c
@@ -4921,12 +4921,25 @@ static void mac80211_sta_set_aggr(struct sigma_dut *dut, const char *intf,
 	}
 }
 
+static void sta_reset_default_mac80211(struct sigma_dut *dut, const char *intf, const char *type);
+
 static enum sigma_cmd_result
 cmd_sta_preset_testparameters(struct sigma_dut *dut, struct sigma_conn *conn,
 			      struct sigma_cmd *cmd)
 {
 	const char *intf = get_param(cmd, "Interface");
+	const char *type = get_param(cmd, "type");
 	const char *val;
+
+	if (dut->program == PROGRAM_UNKNOWN) {
+		switch (get_driver_type(dut)) {
+		case DRIVER_MAC80211:
+			sta_reset_default_mac80211(dut, intf, type);
+			break;
+		default:
+			break;
+		}
+	}
 
 	val = get_param(cmd, "FT_DS");
 	if (val) {
@@ -8028,7 +8041,9 @@ static void sta_reset_default_mac80211(struct sigma_dut *dut, const char *intf,
 {
 	int i;
 
-	if (dut->program == PROGRAM_VHT || dut->program == PROGRAM_HT) {
+	if (dut->program == PROGRAM_VHT ||
+	    dut->program == PROGRAM_HT ||
+	    dut->program == PROGRAM_UNKNOWN) {
 		mod_vht_cap_bit(dut, VHT_CAP_SU_BEAMFORMEE_CAPABLE, 1);
 		mod_vht_cap_bit(dut, VHT_CAP_MU_BEAMFORMEE_CAPABLE, 0);
 		mod_vht_cap_bit(dut, VHT_CAP_SHORT_GI_160, 0);

--- a/sta.c
+++ b/sta.c
@@ -7946,6 +7946,7 @@ static void sta_reset_default_mac80211(struct sigma_dut *dut, const char *intf,
 	if (dut->program == PROGRAM_VHT) {
 		mod_vht_cap_bit(dut, VHT_CAP_SU_BEAMFORMEE_CAPABLE, 1);
 		mod_vht_cap_bit(dut, VHT_CAP_MU_BEAMFORMEE_CAPABLE, 0);
+		mod_vht_cap_bit(dut, VHT_CAP_SHORT_GI_160, 0);
 		mod_vht_cap_bit(dut, VHT_CAP_SHORT_GI_80, 1);
 		mod_vht_cap_bit(dut, VHT_CAP_RXLDPC, 1);
 

--- a/utils.c
+++ b/utils.c
@@ -704,7 +704,6 @@ int random_get_bytes(char *buf, size_t len)
 	return rc != len ? -1 : 0;
 }
 
-
 int get_enable_disable(const char *val)
 {
 	if (strcasecmp(val, "enable") == 0 ||
@@ -742,7 +741,6 @@ int wcn_driver_cmd(const char *ifname, char *buf)
 	return res;
 }
 
-
 int set_ipv6_addr(struct sigma_dut *dut, const char *ip, const char *mask,
 		  const char *ifname)
 {
@@ -765,4 +763,32 @@ int set_ipv6_addr(struct sigma_dut *dut, const char *ip, const char *mask,
 		return -1;
 
 	return 0;
+}
+
+int get_phy80211_name(struct sigma_dut *dut, const char *intf)
+{
+	FILE *fp;
+	char name[256];
+	int idx;
+
+	snprintf(name, sizeof(name), "/sys/class/net/%s/phy80211/name", intf);
+	if (!file_exists(name)) {
+		sigma_dut_print(dut, DUT_MSG_ERROR, "file %s does not exist", name);
+		return -1;
+	}
+
+	fp = fopen(name, "r");
+	if (!fp) {
+		sigma_dut_print(dut, DUT_MSG_ERROR, "can't open %s", name);
+		return -1;
+	}
+
+	if (fscanf(fp, "phy%d", &idx) != 1) {
+		sigma_dut_print(dut, DUT_MSG_ERROR, "can't parse %s", name);
+		fclose(fp);
+		return -1;
+	}
+
+	fclose(fp);
+	return idx;
 }

--- a/wpa_helpers.c
+++ b/wpa_helpers.c
@@ -627,6 +627,12 @@ int set_network(const char *ifname, int id, const char *field,
 	return wpa_command(ifname, buf);
 }
 
+int set_network_num(const char *ifname, int id, const char *field, int value)
+{
+	char buf[200];
+	snprintf(buf, sizeof(buf), "SET_NETWORK %d %s %d", id, field, value);
+	return wpa_command(ifname, buf);
+}
 
 int set_network_quoted(const char *ifname, int id, const char *field,
 		       const char *value)

--- a/wpa_helpers.h
+++ b/wpa_helpers.h
@@ -45,6 +45,7 @@ int get_wpa_cli_events(struct sigma_dut *dut, struct wpa_ctrl *mon,
 int add_network(const char *ifname);
 int set_network(const char *ifname, int id, const char *field,
 		const char *value);
+int set_network_num(const char *ifname, int id, const char *field, int value);
 int set_network_quoted(const char *ifname, int id, const char *field,
 		       const char *value);
 int add_cred(const char *ifname);


### PR DESCRIPTION
Hi all,

This PR enables support of 11n and 11ac STA certification programs for generic mac80211/cfg80211 Linux wireless drivers. Current implementation covers major part of 11n and 11ac STA programs using only standard features provided by Linux kernel and such wireless tools as wpa_supplicant and iw. Note that some of those features are fairly new, so most drivers do not yet support them at the moment.

Suggested approach is fairly straightforward: add new DRIVER_MAC80211 type and handle it wherever it is needed applying required configuration using either _wpa_supplicant_ commands or _iw_ commands.

All the required kernel/wpa_supplicant/iw bits have been already upstreamed to those projects:
*  kernel: AMPDU configuration added by commit ade274b23e41 ("nl80211: Add support to configure TID specific retry configuration")
* kernel: AMSDU configuration added by commit 33462e68231b ("cfg80211: add support for TID specific AMSDU configuration")
* iw: tidconf command for per-TID per-node AMSDU/AMPDU controls added by commit 71ad41cd3d09 ("iw: add TID specific configuration command")
* wpa_supplicant: STBC HT settings added by commit cdeea70f59d0 ("wpa_supplicant: Allow overriding HT STBC capabilities").

Regards,
Sergey