### PR TITLE
make: use pkg-config to gather libnl include path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,9 @@ LIBS += -ldl
 endif
 
 ifdef NL80211_SUPPORT
-CFLAGS += -DNL80211_SUPPORT -I /usr/include/libnl3
+PKG_CONFIG ?= pkg-config
+CFLAGS += -DNL80211_SUPPORT
+CFLAGS += $(shell $(PKG_CONFIG) --cflags libnl-3.0)
 LIBS += -lnl-3 -lnl-genl-3
 endif
 


### PR DESCRIPTION
This helps sigma_dut build be more portable (eg. buildroot
package).

Signed-off-by: Thomas Pedersen <thomas@adapt-ip.com>